### PR TITLE
2.0.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mcmcHammer
 Type: Package
 Title: Tools for managing MCMC chains
-Version: 2.0.1
-Date: 2025-06-16
+Version: 2.0.2
+Date: 2025-06-24
 Authors@R: 
 	c(
 		person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# mcmHammer 2.0.2 (2025-06-24)
+o `hammer_extract()` now allows extracting multiple parameters with different index patterns using the `indices` argument.  
+o Fixed sometimes-fatal bug in `hammer_subset()`.  
+
 # mcmHammer 2.0.1 (2025-06-16)
 o `hammer_subset()` now allows selecting multiple parameters with different index patterns using the `indices` argument.  
 o Fix bug in `hammer_summarize()` where `$summary` tag was left out and summaries put into top-level element.  

--- a/R/hammer_subset.r
+++ b/R/hammer_subset.r
@@ -26,6 +26,7 @@
 #' indices <- list(list(i = TRUE), list(j = TRUE))
 #' params <- c('alpha', 'beta')
 #' complex <- hammer_subset(mcmc, param = params, indices = indices)
+#' head(complex)
 #'
 #' @export
 hammer_subset <- function(
@@ -83,10 +84,20 @@ hammer_subset <- function(
 	cnames <- colnames(mcmc_samples[[1]])
 	for (n_chain in 1:n_chains) {
 		if (keep) {
-			mcmc_samples[[n_chain]] <- mcmc_samples[[n_chain]][ , params, drop = FALSE]
+
+			this_chain <- mcmc_samples[[n_chain]]
+			this_chain <- as.matrix(this_chain)
+			this_chain <- this_chain[ , params, drop = FALSE]
+
 		} else {
-			mcmc_samples[[n_chain]] <- mcmc_samples[[n_chain]][ , !(cnames %in% params), drop = FALSE]
+		
+			this_chain <- mcmc_samples[[n_chain]]
+			this_chain <- as.matrix(this_chain)
+			this_chain <- this_chain[ , !(cnames %in% params), drop = FALSE]
+
 		}
+		this_chain <- coda::as.mcmc(this_chain)
+		mcmc_samples[[n_chain]] <- this_chain
 	}
 
 	if (!is.null(mcmc_summaries)) {


### PR DESCRIPTION
# mcmHammer 2.0.2 (2025-06-24)
o `hammer_extract()` now allows extracting multiple parameters with different index patterns using the `indices` argument.  
o Fixed sometimes-fatal bug in `hammer_subset()`.  
